### PR TITLE
Hotfix for logical error in earnings()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,5 +21,5 @@ Imports:
     tibble,
     tidyr
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.0.2
+RoxygenNote: 7.1.0
 VignetteBuilder: knitr

--- a/R/stock.service.R
+++ b/R/stock.service.R
@@ -171,12 +171,13 @@ dividends <- function (symbol, timePeriod = "3m") {
 #'
 #' @param symbol stock symbol
 #' @param lastN (1) number of periods to report
+#' @param period period to pull earnings from (annual/quarter)
 #' @return a dataframe
 #' @export
 #' @examples
-#' earnings("AAPL", lastN =4)
-earnings <- function (symbol, lastN=1) {
-  endpoint <- glue::glue('/stock/{symbol}/earnings/{lastN}/');
+#' earnings("AAPL", "annual", lastN =4)
+earnings <- function (symbol, period = "quarter", lastN=1) {
+  endpoint <- glue::glue('/stock/{symbol}/earnings/{lastN}?period={period}');
   res = iex_api(endpoint);
   if (res$status) return (tibble::as_tibble(list()))
   data <- res$content$earnings

--- a/man/earnings.Rd
+++ b/man/earnings.Rd
@@ -5,10 +5,12 @@
 \title{Retrieve Earnings data for a given company including the actual EPS, consensus, and fiscal period.
 Earnings are available quarterly (last 4 quarters) and annually (last 4 years).}
 \usage{
-earnings(symbol, lastN = 1)
+earnings(symbol, period = "quarter", lastN = 1)
 }
 \arguments{
 \item{symbol}{stock symbol}
+
+\item{period}{period to pull earnings from (annual/quarter)}
 
 \item{lastN}{(1) number of periods to report}
 }
@@ -22,5 +24,5 @@ Data Weighting: 1000 mesaage units per symbol per period
 Data Schedule: Updates at 9am, 11am, 12pm UTC every da
 }
 \examples{
-earnings("AAPL", lastN =4)
+earnings("AAPL", "annual", lastN =4)
 }


### PR DESCRIPTION
I noticed that the IEX endpoint for earnings allows you to specify what period type you'd like to pull for earnings, and in your library there is no way to do so. I've adjusted the library for this. Thanks for putting in this great work! Its been a huge help for me. 